### PR TITLE
Patch 2 for python 3

### DIFF
--- a/pyscreen/__init__.py
+++ b/pyscreen/__init__.py
@@ -1,2 +1,2 @@
-from command import *
-from session import *
+from .command import *
+from .session import *

--- a/pyscreen/session.py
+++ b/pyscreen/session.py
@@ -1,5 +1,4 @@
-import command
-
+from .command import *
 class ScreenSession():
 
     id = None


### PR DESCRIPTION
In order to run under python 3 we need to indicate were python should find library